### PR TITLE
Adding `lephare` as an official dependency of `rail_lephare`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
+    "lephare",
     "pz-rail-base",
     "qp-prob[full]",
 ]


### PR DESCRIPTION
Since lephare was not pip installable, we didn't initially include it as a dependency. Now that we can pip install, we'll include it in the pyproject.toml.
