### PR TITLE
Fixed model error and changed code to set run without symlink

### DIFF
--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -187,17 +187,19 @@ class LephareEstimator(CatEstimator):
         self.zmin = float(Z_STEP.split(",")[1])
         self.zmax = float(Z_STEP.split(",")[2])
         self.nzbins = int((self.zmax - self.zmin) / self.zstep)
+        CatEstimator.open_model(self, **self.config)
+
+        if self.config["run_dir"] == "None":
+            self.run_dir = self.model["run_dir"]
+        else:
+            self.run_dir = self.config["run_dir"]
+        _update_lephare_env(None, self.run_dir)
 
     def _process_chunk(self, start, end, data, first):
-        """Process an individual chunk of sources using lephare
+        """Process an individual chunk of sources using lephare. 
 
         Run the equivalent of zphota and get the PDF for every source.
         """
-        if self.config["run_dir"] == "None":
-            run_dir = self.model["run_dir"]
-        else:
-            run_dir = self.config["run_dir"]
-        _update_lephare_env(None, run_dir)
         # Create the lephare input table
         input = _rail_to_lephare_input(data, self.config.bands, self.config.err_bands)
         # Set the desired offsets estimate config overide lephare config overide inform offsets

--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -179,10 +179,6 @@ class LephareEstimator(CatEstimator):
         self.zmax = float(Z_STEP.split(",")[2])
         self.nzbins = int((self.zmax - self.zmin) / self.zstep)
 
-    def open_model(self, **kwargs):
-        CatEstimator.open_model(self, **kwargs)
-        self.modeldict = self.model
-
     def _estimate_pdf(self, onesource):
         """Return the pdf of a single source.
 
@@ -198,8 +194,7 @@ class LephareEstimator(CatEstimator):
 
         Run the equivalent of zphota and get the PDF for every source.
         """
-        modeldict = self.modeldict
-        run_dir = modeldict["run_dir"]
+        run_dir = self.model["run_dir"]
         _update_lephare_env(None, run_dir)
         # Create the lephare input table
         input = _rail_to_lephare_input(data, self.config.bands, self.config.err_bands)

--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -188,16 +188,6 @@ class LephareEstimator(CatEstimator):
         self.zmax = float(Z_STEP.split(",")[2])
         self.nzbins = int((self.zmax - self.zmin) / self.zstep)
 
-    def _estimate_pdf(self, onesource):
-        """Return the pdf of a single source.
-
-        Do we want to resample on RAIL z grid?
-        """
-        # Check this is the best way to access pdf
-        pdf = onesource.pdfmap[11]  # 11 = Bayesian galaxy redshift
-        # return the PDF as an array alongside lephare native zgrid
-        return np.array(pdf.vPDF), np.array(pdf.xaxis)
-
     def _process_chunk(self, start, end, data, first):
         """Process an individual chunk of sources using lephare
 

--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -167,6 +167,15 @@ class LephareEstimator(CatEstimator):
                 "autoadapt will be run if that key is set in the config."
             ),
         ),
+        run_dir=Param(
+            str,
+            "None",
+            msg=(
+                "Override for the LEPHAREWORK directory. If None we load it "
+                "from the model which is set during the inform stage. This "
+                "is to facilitate manually moving intermediate files."
+            ),
+        ),
     )
 
     def __init__(self, args, comm=None):
@@ -194,7 +203,10 @@ class LephareEstimator(CatEstimator):
 
         Run the equivalent of zphota and get the PDF for every source.
         """
-        run_dir = self.model["run_dir"]
+        if self.config["run_dir"] == "None":
+            run_dir = self.model["run_dir"]
+        else:
+            run_dir = self.config["run_dir"]
         _update_lephare_env(None, run_dir)
         # Create the lephare input table
         input = _rail_to_lephare_input(data, self.config.bands, self.config.err_bands)

--- a/tests/lephare/test_algos.py
+++ b/tests/lephare/test_algos.py
@@ -30,6 +30,7 @@ def test_informer_and_estimator(test_data_dir: str):
     testFile = os.path.join(test_data_dir, "output_table_conv_test.hdf5")
     traindata_io = tables_io.read(trainFile)
     testdata_io = tables_io.read(testFile)
+    # Load the test params with a sparse redshift grid
     lephare_config_file = os.path.join(test_data_dir, "lsst.para")
     lephare_config = lp.read_config(lephare_config_file)
     lp.data_retrieval.get_auxiliary_data(keymap=lephare_config)
@@ -39,6 +40,7 @@ def test_informer_and_estimator(test_data_dir: str):
         nondetect_val=np.nan,
         model="lephare.pkl",
         hdf5_groupname="",
+        lephare_config=lephare_config,
     )
 
     inform_lephare.inform(traindata_io)

--- a/tests/lephare/test_algos.py
+++ b/tests/lephare/test_algos.py
@@ -33,7 +33,9 @@ def test_informer_and_estimator(test_data_dir: str):
     # Load the test params with a sparse redshift grid
     lephare_config_file = os.path.join(test_data_dir, "lsst.para")
     lephare_config = lp.read_config(lephare_config_file)
-    lp.data_retrieval.get_auxiliary_data(keymap=lephare_config)
+    lp.data_retrieval.get_auxiliary_data(
+        keymap=lephare_config, additional_files=["examples/output.para"]
+    )
 
     inform_lephare = LephareInformer.make_stage(
         name="inform_Lephare",


### PR DESCRIPTION
Closes #36 

We should perhaps set the link to the run directory in a more robust way. currently I get it from the default work directory and go up a level to runs. We also might wnat to make it overwritable in the estimator so that the folder can be moved between systems

Using the symlinked $cache/lephare/work directory creates the possibility of two informers using it simultaneously and intereferring with the default location during local runs. rail_lepahre should use completely independent work directories using the informer name.


## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
