### PR TITLE
Setting lephare config from stage params

### DIFF
--- a/examples/small_demo.ipynb
+++ b/examples/small_demo.ipynb
@@ -91,6 +91,10 @@
     "    nondetect_val=np.nan,\n",
     "    model=\"lephare.pkl\",\n",
     "    hdf5_groupname=\"\",\n",
+    "    # Use a sparse redshift grid to speed up the notebook\n",
+    "    zmin=0,\n",
+    "    zmax=5,\n",
+    "    nzbins=51,\n",
     ")\n",
     "\n",
     "inform_lephare.inform(traindata_io)"
@@ -203,7 +207,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -66,6 +66,10 @@ class LephareInformer(CatInformer):
         """Init function, init config stuff (COPIED from rail_bpz)"""
         CatInformer.__init__(self, args, comm=comm)
         self.lephare_config = self.config["lephare_config"]
+        # We need to ensure the requested redshift grid is propagated
+        Z_STEP=f"{},{self.zmin},{self.zmax}"
+        print(f"rail_lephare is setting the z grid to {Z_STEP} based on the informer params.")
+        self.config["lephare_config"]['Z_STEP']=Z_STEP
         # We create a run directory with the informer name
         self.run_dir = _set_run_dir(self.config["name"])
 
@@ -177,13 +181,13 @@ class LephareEstimator(CatEstimator):
     def __init__(self, args, comm=None):
         CatEstimator.__init__(self, args, comm=comm)
         self.lephare_config = self.config["lephare_config"]
-        Z_STEP = self.lephare_config["Z_STEP"]
+        CatEstimator.open_model(self, **self.config)
+        Z_STEP=self.model["lephare_config"]["Z_STEP"]
+        self.lephare_config["Z_STEP"]=Z_STEP
         self.zstep = float(Z_STEP.split(",")[0])
         self.zmin = float(Z_STEP.split(",")[1])
         self.zmax = float(Z_STEP.split(",")[2])
         self.nzbins = int((self.zmax - self.zmin) / self.zstep)
-        CatEstimator.open_model(self, **self.config)
-
         if self.config["run_dir"] == "None":
             self.run_dir = self.model["run_dir"]
         else:

--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -67,7 +67,8 @@ class LephareInformer(CatInformer):
         CatInformer.__init__(self, args, comm=comm)
         self.lephare_config = self.config["lephare_config"]
         # We need to ensure the requested redshift grid is propagated
-        Z_STEP=f"{},{self.zmin},{self.zmax}"
+        self.dz=(self.zmax-self.zmin)/(self.nzbins-1)
+        Z_STEP=f"{self.dz},{self.zmin},{self.zmax}"
         print(f"rail_lephare is setting the z grid to {Z_STEP} based on the informer params.")
         self.config["lephare_config"]['Z_STEP']=Z_STEP
         # We create a run directory with the informer name

--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -67,9 +67,12 @@ class LephareInformer(CatInformer):
         CatInformer.__init__(self, args, comm=comm)
         self.lephare_config = self.config["lephare_config"]
         # We need to ensure the requested redshift grid is propagated
+        self.zmin=self.config["zmin"]
+        self.zmax=self.config["zmax"]
+        self.nzbins=self.config["nzbins"]
         self.dz=(self.zmax-self.zmin)/(self.nzbins-1)
         Z_STEP=f"{self.dz},{self.zmin},{self.zmax}"
-        print(f"rail_lephare is setting the z grid to {Z_STEP} based on the informer params.")
+        print(f"rail_lephare is setting the Z_STEP config to {Z_STEP} based on the informer params.")
         self.config["lephare_config"]['Z_STEP']=Z_STEP
         # We create a run directory with the informer name
         self.run_dir = _set_run_dir(self.config["name"])

--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -8,6 +8,27 @@ from astropy.table import Table
 import qp
 import importlib
 
+# We start with the COSMOS default and override with LSST specific values.
+lsst_default_config=lp.default_cosmos_config
+lsst_default_config.update({'CAT_IN': 'bidon',
+ 'ERR_SCALE': '0.02,0.02,0.02,0.02,0.02,0.02',
+ 'FILTER_CALIB': '0,0,0,0,0,0',
+ 'FILTER_FILE': 'filter_lsst',
+ 'FILTER_LIST': 'lsst/total_u.pb,lsst/total_g.pb,lsst/total_r.pb,lsst/total_i.pb,lsst/total_z.pb,lsst/total_y3.pb',
+ 'GAL_LIB': 'LSST_GAL_BIN',
+ 'GAL_LIB_IN': 'LSST_GAL_BIN',
+ 'GAL_LIB_OUT': 'LSST_GAL_MAG',
+ 'GLB_CONTEXT': '63',
+ 'INP_TYPE': 'M',
+ 'MABS_CONTEXT': '63',
+ 'MABS_REF': '1',
+ 'QSO_LIB': 'LSST_QSO_BIN',
+ 'QSO_LIB_IN': 'LSST_QSO_BIN',
+ 'QSO_LIB_OUT': 'LSST_QSO_MAG',
+ 'STAR_LIB': 'LSST_STAR_BIN',
+ 'STAR_LIB_IN': 'LSST_STAR_BIN',
+ 'STAR_LIB_OUT': 'LSST_STAR_MAG',
+ 'ZPHOTLIB': 'LSST_STAR_MAG,LSST_GAL_MAG,LSST_QSO_MAG'})
 
 class LephareInformer(CatInformer):
     """Inform stage for LephareEstimator
@@ -29,9 +50,13 @@ class LephareInformer(CatInformer):
         redshift_col=SHARED_PARAMS,
         lephare_config=Param(
             dict,
+<<<<<<< Updated upstream
             lp.keymap_to_string_dict(lp.read_config(
                 "{}/{}".format(os.path.dirname(os.path.abspath(__file__)), "lsst.para")
             )),
+=======
+            lsst_default_config,
+>>>>>>> Stashed changes
             msg="The lephare config keymap.",
         ),
         star_config=Param(
@@ -108,10 +133,10 @@ class LephareInformer(CatInformer):
 
         # The three main lephare specific inform tasks
         lp.prepare(
-            lp.string_dict_to_keymap(self.lephare_config),
-            star_config=lp.string_dict_to_keymap(self.config["star_config"]),
-            gal_config=lp.string_dict_to_keymap(self.config["gal_config"]),
-            qso_config=lp.string_dict_to_keymap(self.config["qso_config"]),
+            self.lephare_config,
+            star_config=self.config["star_config"],
+            gal_config=self.config["gal_config"],
+            qso_config=self.config["qso_config"],
         )
 
         # Spectroscopic redshifts
@@ -213,7 +238,13 @@ class LephareEstimator(CatEstimator):
             offsets = [a0, a1]
         elif not self.config["offsets"]:
             offsets = self.model["offsets"]
+<<<<<<< Updated upstream
         output, pdfs, zgrid = lp.process(lp.string_dict_to_keymap(self.lephare_config), input, offsets=offsets)
+=======
+        output, pdfs, zgrid = lp.process(
+            self.lephare_config, input, offsets=offsets
+        )
+>>>>>>> Stashed changes
         self.zgrid = zgrid
 
         ng = data[self.config.bands[0]].shape[0]

--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -50,13 +50,7 @@ class LephareInformer(CatInformer):
         redshift_col=SHARED_PARAMS,
         lephare_config=Param(
             dict,
-<<<<<<< Updated upstream
-            lp.keymap_to_string_dict(lp.read_config(
-                "{}/{}".format(os.path.dirname(os.path.abspath(__file__)), "lsst.para")
-            )),
-=======
             lsst_default_config,
->>>>>>> Stashed changes
             msg="The lephare config keymap.",
         ),
         star_config=Param(
@@ -238,13 +232,9 @@ class LephareEstimator(CatEstimator):
             offsets = [a0, a1]
         elif not self.config["offsets"]:
             offsets = self.model["offsets"]
-<<<<<<< Updated upstream
-        output, pdfs, zgrid = lp.process(lp.string_dict_to_keymap(self.lephare_config), input, offsets=offsets)
-=======
         output, pdfs, zgrid = lp.process(
             self.lephare_config, input, offsets=offsets
         )
->>>>>>> Stashed changes
         self.zgrid = zgrid
 
         ng = data[self.config.bands[0]].shape[0]

--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -188,10 +188,10 @@ class LephareEstimator(CatEstimator):
         CatEstimator.open_model(self, **self.config)
         Z_STEP=self.model["lephare_config"]["Z_STEP"]
         self.lephare_config["Z_STEP"]=Z_STEP
-        self.zstep = float(Z_STEP.split(",")[0])
+        self.dz = float(Z_STEP.split(",")[0])
         self.zmin = float(Z_STEP.split(",")[1])
         self.zmax = float(Z_STEP.split(",")[2])
-        self.nzbins = int((self.zmax - self.zmin) / self.zstep)
+        self.nzbins = int((self.zmax - self.zmin) / self.dz)
         if self.config["run_dir"] == "None":
             self.run_dir = self.model["run_dir"]
         else:

--- a/tests/lephare/test_algos.py
+++ b/tests/lephare/test_algos.py
@@ -43,6 +43,10 @@ def test_informer_and_estimator(test_data_dir: str):
         model="lephare.pkl",
         hdf5_groupname="",
         lephare_config=lp.keymap_to_string_dict(lephare_config),
+        # Use a very sparse redshift grid to speed up test:
+        zmin=0,
+        zmax=5,
+        nzbins=6,
     )
 
     inform_lephare.inform(traindata_io)

--- a/tests/lephare/test_algos.py
+++ b/tests/lephare/test_algos.py
@@ -22,6 +22,8 @@ def test_informer_basic():
 
     assert inform_lephare.name == "LephareInformer"
     assert inform_lephare.config["name"] == "inform_Lephare"
+    # Check config zgrid updated to stage param defaults:
+    assert inform_lephare.config["lephare_config"]["Z_STEP"]=='0.01,0.0,3.0'
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Waiting for other PRs to merge before merging to ensure config values consistent with updated string dict format

Closes #43 

I want to wait for the lephare string dict changes and the COSMOS param defaults to merged before merging to ensure merge conflicts are handled correctly

## Problem & Solution Description (including issue #)

The redshift grid was being read from the lepahre config which could be distinct from the stage params and cause a confusion. WE instead overwrite the lephare config from the params. This should allow the notebook to be sped up by setting a sparse redshift grid in the inform params.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
