### PR TITLE
Allow estimate to run without redshift

### DIFF
--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -243,7 +243,7 @@ def _rail_to_lephare_input(data, mag_cols, mag_err_cols):
 
 
     """
-    ng = data["redshift"].shape[0]
+    ng = data[mag_cols[0]].shape[0]
     # Make input catalogue in standard lephare format
     input = Table()
     try:
@@ -256,7 +256,10 @@ def _rail_to_lephare_input(data, mag_cols, mag_err_cols):
         input[mag_err_cols[n]] = data[mag_err_cols[n]].T
     # Set context to use all bands
     input["context"] = np.sum([2**n for n in np.arange(ng)])
-    input["zspec"] = data["redshift"]
+    try:
+        input["zspec"] = data["redshift"]
+    except KeyError:
+        input["zspec"] = np.full(ng,-99.)
     input["string_data"] = " "
     return input
 


### PR DESCRIPTION
Closes #49

Allow running of estimate without redshift


## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
