### PR TITLE
Update for ceci version 2

### DIFF
--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -81,9 +81,9 @@ class LephareInformer(CatInformer):
         ),
     )
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Init function, init config stuff (COPIED from rail_bpz)"""
-        CatInformer.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self.lephare_config = self.config["lephare_config"]
         # We need to ensure the requested redshift grid is propagated
         self.zmin=self.config["zmin"]
@@ -204,8 +204,8 @@ class LephareEstimator(CatEstimator):
         ),
     )
 
-    def __init__(self, args, comm=None):
-        CatEstimator.__init__(self, args, comm=comm)
+    def __init__(self, args, **kwargs):
+        super().__init__(self, args, **kwargs)
         CatEstimator.open_model(self, **self.config)
         self.lephare_config = self.model["lephare_config"]
         Z_STEP=self.model["lephare_config"]["Z_STEP"]


### PR DESCRIPTION
This PR updates the constructors of all stage subclasses to work with ceci version 2, in which aliases are specified in the constructor. A similar PR has been opened for each RAIL repo.

The main change is to the the constructors to accept any keywords with **kwargs and pass them to the parent class.

I have also removed any constructors which did not do anything except call the parent class constructor. Since this happens automatically if you omit the constructor, these were redundant.

Finally, in constructors I have changed I have removed hard-coded parent classes in favour of the python3 recommended super() function. If the parent class are changed in the future the constructor will still work.