### PR TITLE
Updated process returns to list of lephare.onesource objects

### DIFF
--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -214,7 +214,10 @@ class LephareEstimator(CatEstimator):
     def __init__(self, args, **kwargs):
         super().__init__(args, **kwargs)
         CatEstimator.open_model(self, **self.config)
-        self.lephare_config = self.model["lephare_config"]
+        if self.config["lephare_config"]:
+            self.lephare_config = self.config["lephare_config"]
+        else:
+            self.lephare_config = self.model["lephare_config"]
         Z_STEP = self.model["lephare_config"]["Z_STEP"]
         self.lephare_config["Z_STEP"] = Z_STEP
         self.dz = float(Z_STEP.split(",")[0])

--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -9,26 +9,31 @@ import qp
 import importlib
 
 # We start with the COSMOS default and override with LSST specific values.
-lsst_default_config=lp.default_cosmos_config.copy()
-lsst_default_config.update({'CAT_IN': 'bidon',
- 'ERR_SCALE': '0.02,0.02,0.02,0.02,0.02,0.02',
- 'FILTER_CALIB': '0,0,0,0,0,0',
- 'FILTER_FILE': 'filter_lsst',
- 'FILTER_LIST': 'lsst/total_u.pb,lsst/total_g.pb,lsst/total_r.pb,lsst/total_i.pb,lsst/total_z.pb,lsst/total_y3.pb',
- 'GAL_LIB': 'LSST_GAL_BIN',
- 'GAL_LIB_IN': 'LSST_GAL_BIN',
- 'GAL_LIB_OUT': 'LSST_GAL_MAG',
- 'GLB_CONTEXT': '63',
- 'INP_TYPE': 'M',
- 'MABS_CONTEXT': '63',
- 'MABS_REF': '1',
- 'QSO_LIB': 'LSST_QSO_BIN',
- 'QSO_LIB_IN': 'LSST_QSO_BIN',
- 'QSO_LIB_OUT': 'LSST_QSO_MAG',
- 'STAR_LIB': 'LSST_STAR_BIN',
- 'STAR_LIB_IN': 'LSST_STAR_BIN',
- 'STAR_LIB_OUT': 'LSST_STAR_MAG',
- 'ZPHOTLIB': 'LSST_STAR_MAG,LSST_GAL_MAG,LSST_QSO_MAG'})
+lsst_default_config = lp.default_cosmos_config.copy()
+lsst_default_config.update(
+    {
+        "CAT_IN": "bidon",
+        "ERR_SCALE": "0.02,0.02,0.02,0.02,0.02,0.02",
+        "FILTER_CALIB": "0,0,0,0,0,0",
+        "FILTER_FILE": "filter_lsst",
+        "FILTER_LIST": "lsst/total_u.pb,lsst/total_g.pb,lsst/total_r.pb,lsst/total_i.pb,lsst/total_z.pb,lsst/total_y3.pb",
+        "GAL_LIB": "LSST_GAL_BIN",
+        "GAL_LIB_IN": "LSST_GAL_BIN",
+        "GAL_LIB_OUT": "LSST_GAL_MAG",
+        "GLB_CONTEXT": "63",
+        "INP_TYPE": "M",
+        "MABS_CONTEXT": "63",
+        "MABS_REF": "1",
+        "QSO_LIB": "LSST_QSO_BIN",
+        "QSO_LIB_IN": "LSST_QSO_BIN",
+        "QSO_LIB_OUT": "LSST_QSO_MAG",
+        "STAR_LIB": "LSST_STAR_BIN",
+        "STAR_LIB_IN": "LSST_STAR_BIN",
+        "STAR_LIB_OUT": "LSST_STAR_MAG",
+        "ZPHOTLIB": "LSST_STAR_MAG,LSST_GAL_MAG,LSST_QSO_MAG",
+    }
+)
+
 
 class LephareInformer(CatInformer):
     """Inform stage for LephareEstimator
@@ -86,13 +91,15 @@ class LephareInformer(CatInformer):
         super().__init__(args, **kwargs)
         self.lephare_config = self.config["lephare_config"]
         # We need to ensure the requested redshift grid is propagated
-        self.zmin=self.config["zmin"]
-        self.zmax=self.config["zmax"]
-        self.nzbins=self.config["nzbins"]
-        self.dz=(self.zmax-self.zmin)/(self.nzbins-1)
-        Z_STEP=f"{self.dz},{self.zmin},{self.zmax}"
-        print(f"rail_lephare is setting the Z_STEP config to {Z_STEP} based on the informer params.")
-        self.config["lephare_config"]['Z_STEP']=Z_STEP
+        self.zmin = self.config["zmin"]
+        self.zmax = self.config["zmax"]
+        self.nzbins = self.config["nzbins"]
+        self.dz = (self.zmax - self.zmin) / (self.nzbins - 1)
+        Z_STEP = f"{self.dz},{self.zmin},{self.zmax}"
+        print(
+            f"rail_lephare is setting the Z_STEP config to {Z_STEP} based on the informer params."
+        )
+        self.config["lephare_config"]["Z_STEP"] = Z_STEP
         # We create a run directory with the informer name
         self.run_dir = _set_run_dir(self.config["name"])
 
@@ -208,8 +215,8 @@ class LephareEstimator(CatEstimator):
         super().__init__(args, **kwargs)
         CatEstimator.open_model(self, **self.config)
         self.lephare_config = self.model["lephare_config"]
-        Z_STEP=self.model["lephare_config"]["Z_STEP"]
-        self.lephare_config["Z_STEP"]=Z_STEP
+        Z_STEP = self.model["lephare_config"]["Z_STEP"]
+        self.lephare_config["Z_STEP"] = Z_STEP
         self.dz = float(Z_STEP.split(",")[0])
         self.zmin = float(Z_STEP.split(",")[1])
         self.zmax = float(Z_STEP.split(",")[2])
@@ -237,12 +244,16 @@ class LephareEstimator(CatEstimator):
             offsets = [a0, a1]
         elif not self.config["offsets"]:
             offsets = self.model["offsets"]
-        output, pdfs, zgrid = lp.process(
-            self.lephare_config, input, offsets=offsets
-        )
-        self.zgrid = zgrid
-
+        output, photozlist = lp.process(self.lephare_config, input, offsets=offsets)
         ng = data[self.config.bands[0]].shape[0]
+        # Unpack the pdfs for galaxies
+        pdfs = []
+        for i in range(ng):
+            pdf = np.array(photozlist[i].pdfmap[11].vPDF)
+            pdfs.append(pdf)
+        zgrid = np.array(photozlist[i].pdfmap[11].xaxis)
+        pdfs = np.array(pdfs)
+        self.zgrid = zgrid
         zmode = np.zeros(ng)
         zmean = np.zeros(ng)
 
@@ -308,7 +319,7 @@ def _rail_to_lephare_input(data, mag_cols, mag_err_cols):
     try:
         input["zspec"] = data["redshift"]
     except KeyError:
-        input["zspec"] = np.full(ng,-99.)
+        input["zspec"] = np.full(ng, -99.0)
     input["string_data"] = " "
     return input
 

--- a/src/rail/estimation/algos/lsst.para
+++ b/src/rail/estimation/algos/lsst.para
@@ -14,7 +14,7 @@ QSO_LIB		LSST_QSO_BIN 			# Binary QSO LIBRARY (-> $ZPHOTWORK/lib_bin/*)
 QSO_FSCALE	1.			# Arbitrary Flux Scale 
 #
 #-------------------  GALAXY LIBRARY (ASCII or BINARY SEDs) ---------------------------
-GAL_SED		 examples/COSMOS_MOD.list            # GALAXMuzzin09_SEDY list (full path)
+GAL_SED		 sed/GAL/COSMOS_SED/COSMOS_MOD.list           # GALAXMuzzin09_SEDY list (full path)
 GAL_LIB	         LSST_GAL_BIN 	                # Binary GAL LIBRARY (-> $ZPHOTWORK/lib_bin/*)
 GAL_FSCALE      1.                      # Arbitrary Flux Scale
 #SEL_AGE 	/data/zphot_vers25_03_03/sed/GAL/HYPERZ/AGE_GISSEL_HZ.dat	# List of Age for GISSEL(full path)

--- a/tests/data/lsst.para
+++ b/tests/data/lsst.para
@@ -14,7 +14,7 @@ QSO_LIB		LSST_QSO_BIN 			# Binary QSO LIBRARY (-> $ZPHOTWORK/lib_bin/*)
 QSO_FSCALE	1.			# Arbitrary Flux Scale 
 #
 #-------------------  GALAXY LIBRARY (ASCII or BINARY SEDs) ---------------------------
-GAL_SED		 examples/COSMOS_MOD.list            # GALAXMuzzin09_SEDY list (full path)
+GAL_SED		 sed/GAL/COSMOS_SED/COSMOS_MOD.list            # GALAXMuzzin09_SEDY list (full path)
 GAL_LIB	         LSST_GAL_BIN 	                # Binary GAL LIBRARY (-> $ZPHOTWORK/lib_bin/*)
 GAL_FSCALE      1.                      # Arbitrary Flux Scale
 #SEL_AGE 	/data/zphot_vers25_03_03/sed/GAL/HYPERZ/AGE_GISSEL_HZ.dat	# List of Age for GISSEL(full path)

--- a/tests/lephare/test_algos.py
+++ b/tests/lephare/test_algos.py
@@ -23,7 +23,7 @@ def test_informer_basic():
     assert inform_lephare.name == "LephareInformer"
     assert inform_lephare.config["name"] == "inform_Lephare"
     # Check config zgrid updated to stage param defaults:
-    assert inform_lephare.config["lephare_config"]["Z_STEP"]=='0.01,0.0,3.0'
+    assert inform_lephare.config["lephare_config"]["Z_STEP"] == "0.01,0.0,3.0"
 
 
 @pytest.mark.slow
@@ -36,7 +36,8 @@ def test_informer_and_estimator(test_data_dir: str):
     lephare_config_file = os.path.join(test_data_dir, "lsst.para")
     lephare_config = lp.read_config(lephare_config_file)
     lp.data_retrieval.get_auxiliary_data(
-        keymap=lephare_config, additional_files=["examples/output.para"]
+        keymap=lephare_config,
+        additional_files=["examples/output.para", "examples/COSMOS_MOD.list"],
     )
 
     inform_lephare = LephareInformer.make_stage(

--- a/tests/lephare/test_algos.py
+++ b/tests/lephare/test_algos.py
@@ -37,7 +37,7 @@ def test_informer_and_estimator(test_data_dir: str):
     lephare_config = lp.read_config(lephare_config_file)
     lp.data_retrieval.get_auxiliary_data(
         keymap=lephare_config,
-        additional_files=["examples/output.para", "examples/COSMOS_MOD.list"],
+        additional_files=["examples/output.para"],
     )
 
     inform_lephare = LephareInformer.make_stage(


### PR DESCRIPTION
This is a change to the lephare code and should be merged after the PyPI has been updated.

Closes #57

I will request a review when PyPI is updated and the tests start breaking


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
