### PR TITLE
move reading model from LephareEstimator.__init__ to _initialize_run

### DIFF
--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -214,8 +214,8 @@ class LephareEstimator(CatEstimator):
         self.zmax: float| None = None
         self.nzbins: int| None = None
 
-    def _initialize_run(self) -> None:
-        CatEstimator.open_model(self, **self.config)
+    def open_model(self, **kwargs):
+        CatEstimator.open_model(self, **kwargs)
         if self.config["lephare_config"]:
             self.lephare_config = self.config["lephare_config"]
         else:

--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -209,6 +209,12 @@ class LephareEstimator(CatEstimator):
 
     def __init__(self, args, **kwargs):
         super().__init__(args, **kwargs)
+        self.lephare_config: dict = {}
+        self.zmin: float| None = None
+        self.zmax: float| None = None
+        self.nzbins: int| None = None
+
+    def _initialize_run(self) -> None:
         CatEstimator.open_model(self, **self.config)
         if self.config["lephare_config"]:
             self.lephare_config = self.config["lephare_config"]


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

#62 

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
