### PR TITLE
Issue/65/allow other posteriors

### DIFF
--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -186,6 +186,26 @@ class LephareEstimator(CatEstimator):
             True,
             msg="Use the zero point offsets computed in the inform stage.",
         ),
+        posterior_output=Param(
+            int,
+            11,
+            msg=(
+                "Which posterior distribution to output."
+                "MASS: 0"
+                "SFR: 1"
+                "SSFR: 2"
+                "LDUST: 3"
+                "LIR: 4"
+                "AGE: 5"
+                "COL1: 6"
+                "COL2: 7"
+                "MREF: 8"
+                "MIN_ZG: 9"
+                "MIN_ZQ: 10"
+                "BAY_ZG: 11"
+                "BAY_ZQ: 12"
+            ),
+        ),
         output_keys=Param(
             list,
             ["Z_BEST", "CHI_BEST", "ZQ_BEST", "CHI_QSO", "MOD_STAR", "CHI_STAR"],
@@ -210,9 +230,9 @@ class LephareEstimator(CatEstimator):
     def __init__(self, args, **kwargs):
         super().__init__(args, **kwargs)
         self.lephare_config: dict = {}
-        self.zmin: float| None = None
-        self.zmax: float| None = None
-        self.nzbins: int| None = None
+        self.zmin: float | None = None
+        self.zmax: float | None = None
+        self.nzbins: int | None = None
 
     def open_model(self, **kwargs):
         CatEstimator.open_model(self, **kwargs)

--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -267,10 +267,11 @@ class LephareEstimator(CatEstimator):
         ng = data[self.config.bands[0]].shape[0]
         # Unpack the pdfs for galaxies
         pdfs = []
+        posterior_output = self.config["posterior_output"]
         for i in range(ng):
-            pdf = np.array(photozlist[i].pdfmap[11].vPDF)
+            pdf = np.array(photozlist[i].pdfmap[posterior_output].vPDF)
             pdfs.append(pdf)
-        zgrid = np.array(photozlist[i].pdfmap[11].xaxis)
+        zgrid = np.array(photozlist[i].pdfmap[posterior_output].xaxis)
         pdfs = np.array(pdfs)
         self.zgrid = zgrid
         zmode = np.zeros(ng)

--- a/tests/lephare/test_algos.py
+++ b/tests/lephare/test_algos.py
@@ -62,6 +62,7 @@ def test_informer_and_estimator(test_data_dir: str):
         model=inform_lephare.get_handle("model"),
         hdf5_groupname="",
         aliases=dict(input="test_data", output="lephare_estim"),
+        use_inform_offsets=True,
     )
 
     lephare_estimated = estimate_lephare.estimate(testdata_io)


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
We may want to output additional posteriors other than the galaxy pdz. This PR adds a simple additional option to specify which posterior to send to the output.

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
