### PR TITLE
remove y3 filter and call y filter instead

### DIFF
--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         sudo apt-get update
         python -m pip install --upgrade pip
+	pip install setuptools
         pip install .
         pip install .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/examples/cosmos_demo.ipynb
+++ b/examples/cosmos_demo.ipynb
@@ -133,8 +133,26 @@
     "    bands=flux_cols,\n",
     "    err_bands=flux_err_cols,\n",
     "    ref_band=flux_cols[0],\n",
+    "    do_prepare = False,\n",
     ")\n",
-    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inform_lephare.do_prepare"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "inform_lephare.inform(data)"
    ]
   },
@@ -279,7 +297,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/examples/cosmos_demo.ipynb
+++ b/examples/cosmos_demo.ipynb
@@ -29,6 +29,8 @@
     "from collections import OrderedDict\n",
     "import os\n",
     "\n",
+    "from rail.core.data import Hdf5Handle\n",
+    "\n",
     "DS = RailStage.data_store\n",
     "DS.__class__.allow_overwrite = True"
    ]
@@ -108,7 +110,9 @@
     "    flux_cols.append(f\"flux_{b}\")\n",
     "    data[f\"flux_err_{b}\"]=flux_err\n",
     "    flux_err_cols.append(f\"flux_err_{b}\")\n",
-    "data[\"redshift\"]=np.array(cosmos[cosmos.colnames[-2]])"
+    "data[\"redshift\"]=np.array(cosmos[cosmos.colnames[-2]])\n",
+    "#this is a temporary fix, to deal with in memory data\n",
+    "dh = DS.add_data('input_data', data, Hdf5Handle, 'temp_data.hdf5')"
    ]
   },
   {
@@ -133,18 +137,9 @@
     "    bands=flux_cols,\n",
     "    err_bands=flux_err_cols,\n",
     "    ref_band=flux_cols[0],\n",
-    "    do_prepare = False,\n",
+    "    do_prepare = True,\n",
     ")\n",
     "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "inform_lephare.do_prepare"
    ]
   },
   {
@@ -180,7 +175,7 @@
     "    ref_band=flux_cols[0],\n",
     ")\n",
     "\n",
-    "lephare_estimated = estimate_lephare.estimate(data)"
+    "lephare_estimated = estimate_lephare.estimate(dh)"
    ]
   },
   {

--- a/examples/small_demo.ipynb
+++ b/examples/small_demo.ipynb
@@ -19,6 +19,8 @@
     "from rail.core.stage import RailStage\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
+    "from rail.core.data import Hdf5Handle\n",
+    "\n",
     "DS = RailStage.data_store\n",
     "DS.__class__.allow_overwrite = True"
    ]
@@ -95,6 +97,8 @@
     "    zmin=0,\n",
     "    zmax=5,\n",
     "    nzbins=51,\n",
+    "    lephare_config=lephare_config,\n",
+    "    do_prepare = True,\n",
     ")\n",
     "\n",
     "inform_lephare.inform(traindata_io)"
@@ -121,7 +125,10 @@
     "    aliases=dict(input=\"test_data\", output=\"lephare_estim\"),\n",
     ")\n",
     "\n",
-    "lephare_estimated = estimate_lephare.estimate(testdata_io)"
+    "#this is a temporary fix, to deal with in memory data\n",
+    "dh = DS.add_data('input_data', testdata_io, Hdf5Handle, 'temp_data.hdf5')\n",
+    "\n",
+    "lephare_estimated = estimate_lephare.estimate(dh)"
    ]
   },
   {
@@ -207,7 +214,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -88,8 +88,18 @@ class LephareInformer(CatInformer):
 
     def __init__(self, args, **kwargs):
         """Init function, init config stuff (COPIED from rail_bpz)"""
+
         super().__init__(args, **kwargs)
         self.lephare_config = self.config["lephare_config"]
+        
+        #Put something in place to allow for not rerunning the prepare stage
+        try:
+            self.do_prepare = self.config["do_prepare"]
+            if self.do_prepare.__class__ is not bool:
+                raise RuntimeError("do_prepare argument must be a bool")
+        except KeyError:
+            self.do_prepare = True
+            
         # We need to ensure the requested redshift grid is propagated
         self.zmin = self.config["zmin"]
         self.zmax = self.config["zmax"]
@@ -133,13 +143,16 @@ class LephareInformer(CatInformer):
         ngal = len(training_data[self.config.ref_band])
 
         # The three main lephare specific inform tasks
-        lp.prepare(
-            self.lephare_config,
-            star_config=self.config["star_config"],
-            gal_config=self.config["gal_config"],
-            qso_config=self.config["qso_config"],
-        )
-
+        if self.do_prepare:
+            lp.prepare(
+                self.lephare_config,
+                star_config=self.config["star_config"],
+                gal_config=self.config["gal_config"],
+                qso_config=self.config["qso_config"],
+            )
+        else:
+            print(f"do_prepare set to False, using precomputed files in {self.run_dir}.")
+            
         # Spectroscopic redshifts
         self.szs = training_data[self.config.redshift_col]
 

--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -12,11 +12,11 @@ import importlib
 lsst_default_config = lp.default_cosmos_config.copy()
 lsst_default_config.update(
     {
-        "CAT_IN": "bidon",
+        "CAT_IN": "undefined",
         "ERR_SCALE": "0.02,0.02,0.02,0.02,0.02,0.02",
         "FILTER_CALIB": "0,0,0,0,0,0",
         "FILTER_FILE": "filter_lsst",
-        "FILTER_LIST": "lsst/total_u.pb,lsst/total_g.pb,lsst/total_r.pb,lsst/total_i.pb,lsst/total_z.pb,lsst/total_y3.pb",
+        "FILTER_LIST": "lsst/total_u.pb,lsst/total_g.pb,lsst/total_r.pb,lsst/total_i.pb,lsst/total_z.pb,lsst/total_y.pb",
         "GAL_LIB": "LSST_GAL_BIN",
         "GAL_LIB_IN": "LSST_GAL_BIN",
         "GAL_LIB_OUT": "LSST_GAL_MAG",

--- a/tests/data/lsst.para
+++ b/tests/data/lsst.para
@@ -29,7 +29,7 @@ AGE_RANGE  0.,15.e9                                     # Age Min-Max in yr
 
 # 
 FILTER_REP   $LEPHAREDIR/filt           # Repository in which the filters are stored
-FILTER_LIST   lsst/total_u.pb,lsst/total_g.pb,lsst/total_r.pb,lsst/total_i.pb,lsst/total_z.pb,lsst/total_y3.pb
+FILTER_LIST   lsst/total_u.pb,lsst/total_g.pb,lsst/total_r.pb,lsst/total_i.pb,lsst/total_z.pb,lsst/total_y.pb
 TRANS_TYPE	 1			# TRANSMISSION TYPE
                                         # 0[-def]: Energy, 1: Nb of photons
 FILTER_CALIB    0,0,0,0,0,0             # 0[-def]:  fnu=ctt 


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
this is just a matter of updating the LSST filter curves in https://github.com/lephare-photoz/lephare-data 
and to call total_y rather than total_y3 here.

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
