### PR TITLE
Overwrite AUTO_ADAPT value if APPLY_SYSSHIFT is set

### DIFF
--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -238,6 +238,10 @@ class LephareEstimator(CatEstimator):
             self.lephare_config = self.config["lephare_config"]
         else:
             self.lephare_config = self.model["lephare_config"]
+        # Use string dictionary config in case keymap passed to estimate stage
+        self.lephare_config = lp.keymap_to_string_dict(
+            lp.all_types_to_keymap(self.lephare_config)
+        )
         Z_STEP = self.model["lephare_config"]["Z_STEP"]
         self.lephare_config["Z_STEP"] = Z_STEP
         self.dz = float(Z_STEP.split(",")[0])

--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -270,7 +270,7 @@ class LephareEstimator(CatEstimator):
                 "AUTO_ADAPT being set to NO to ensure "
                 "it is not rerun on random chunks as APPLY_SYSSHIFT is set."
             )
-            self.lephare_config.get["AUTO_ADAPT"] = "NO"
+            self.lephare_config["AUTO_ADAPT"] = "NO"
         output, photozlist = lp.process(self.lephare_config, input)
         ng = data[self.config.bands[0]].shape[0]
         # Unpack the pdfs for galaxies

--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -164,12 +164,10 @@ class LephareInformer(CatInformer):
         input = _rail_to_lephare_input(
             training_data, self.config.bands, self.config.err_bands
         )
-        if self.config["lephare_config"]["AUTO_ADAPT"] == "YES":
-            offsets = lp.calculate_offsets_from_input(
-                self.config["lephare_config"], input
-            )
-        else:
-            offsets = None
+        # This will return zeros if AUTO_ADAPT is NO
+        offsets = lp.calculate_offsets_from_input(
+            self.config["lephare_config"], input
+        )
         # We must make a string dictionary to allow pickling and saving
         lephare_config = lp.keymap_to_string_dict(
             lp.all_types_to_keymap(self.config["lephare_config"])

--- a/src/rail/estimation/algos/lephare.py
+++ b/src/rail/estimation/algos/lephare.py
@@ -176,6 +176,7 @@ class LephareInformer(CatInformer):
         )
         # Give principle inform config 'model' to instance.
         self.model = dict(
+            lephare_version=lp.__version__,
             lephare_config=lephare_config,
             offsets=offsets,
             run_dir=self.run_dir,


### PR DESCRIPTION
Closes #76 

We want to make sure users do not accidentally run AUTO_ADAPT on every chunk. This could either be because use_inform_offsets is true and it takes the SYSSHIFT from the inform model or it has been set by the user possibly for specific regions. We add a simple clause to switch it from YES to NO in such a case.

## Problem & Solution Description (including issue #)


## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
